### PR TITLE
Update provisioner.sh

### DIFF
--- a/scripts/provisioner.sh
+++ b/scripts/provisioner.sh
@@ -75,6 +75,8 @@ then
   base64 --decode <<< "${PRE_CILIUM_INSTALL_SCRIPT}" | bash
 fi
 
+helm repo add isovalent https://helm.isovalent.com/
+helm repo add cilium https://helm.cilium.io/
 # Get the latest information about charts from the respective chart repositories.
 helm repo update
 


### PR DESCRIPTION
I dont know if I'm too new here, and I had to add `helm repo add isovalent https://helm.isovalent.com/` for my CUPE environment

I think it's ok to hardcode the name isovalent/cilium and URL here since it's that's all the possiblity that I can think of for now. we might want to set it as var in the future if we need to add some other repo for other purpose.