### PR TITLE
This commit fixes a bug that removed CILIUM_HELM_EXTRA_ARGS

### DIFF
--- a/scripts/provisioner.sh
+++ b/scripts/provisioner.sh
@@ -78,10 +78,23 @@ fi
 # Get the latest information about charts from the respective chart repositories.
 helm repo update
 
-# Replace variables in the values file and pipe it to 'helm upgrade --install'.
-envsubst < "${CILIUM_HELM_VALUES_FILE}" | \
+# Substitute environment variables into the Cilium Helm values file.
+envsubst < "${CILIUM_HELM_VALUES_FILE}" > tmp1 
+
+if [[ "${CILIUM_HELM_VALUES_OVERRIDE_FILE}" != "" ]];
+then
+  # Substitute environment variables into the Cilium Helm values override file.
+  envsubst < "${CILIUM_HELM_VALUES_OVERRIDE_FILE}" | \
   helm upgrade --install "${CILIUM_HELM_RELEASE_NAME}" "${CILIUM_HELM_CHART}" \
-    --version "${CILIUM_HELM_VERSION}" -n "${CILIUM_NAMESPACE}" -f /dev/stdin ${CILIUM_HELM_EXTRA_ARGS}
+  --version "${CILIUM_HELM_VERSION}" -n "${CILIUM_NAMESPACE}" -f tmp1 -f /dev/stdin ${CILIUM_HELM_EXTRA_ARGS}
+  rm -f tmp1
+else
+  envsubst < tmp1 | \
+  helm upgrade --install "${CILIUM_HELM_RELEASE_NAME}" "${CILIUM_HELM_CHART}" \
+  --version "${CILIUM_HELM_VERSION}" -n "${CILIUM_NAMESPACE}" -f /dev/stdin ${CILIUM_HELM_EXTRA_ARGS}
+  rm -f tmp1
+fi
+
 
 # Run any post-install script we may have been provided with.
 if [[ "${POST_CILIUM_INSTALL_SCRIPT}" != "" ]];


### PR DESCRIPTION
The bug has been introduced in https://github.com/isovalent/terraform-k8s-cilium/commit/7f3e69861ed39b19fb8c797aa09dad0e1d70033c.

I tested with 

```
variable "cilium_helm_values_override_file" {
  default     = "override.yaml"
  description = "The path to the override file containing the values to use when installing Cilium."
  type        = string
}
```

Where override was 
```
cilium:
 kubeProxyReplacement: partial
```

And without an `override.yaml`



Also I made a test with
```
//cilium_helm_extra_args
```
