### PR TITLE
Update provisioner.sh

### DIFF
--- a/scripts/provisioner.sh
+++ b/scripts/provisioner.sh
@@ -68,7 +68,7 @@ export IPSEC_ENABLED
 # Manually create the 'ServiceMonitor' CRD from 'kube-prometheus' so we can enable the creation of 'ServiceMonitor' resources in the Cilium Helm chart.
 if [[ "${INSTALL_KUBE_PROMETHEUS_CRDS}" == "true" ]];
 then
-  kubectl apply -f "https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/release-0.11/manifests/setup/0servicemonitorCustomResourceDefinition.yaml"
+  kubectl apply -f "https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/release-0.13/manifests/setup/0servicemonitorCustomResourceDefinition.yaml"
   until kubectl get servicemonitors --all-namespaces;
   do
       echo "Waiting for the 'servicemonitors' CRD...";


### PR DESCRIPTION
To update the version of Prometheus CRDS. The current hardcoded version v0.11 is old and sometimes through 404. The version for prometheus-operator/kube-prometheus can be upgraded to the latest release [v0.13](https://github.com/prometheus-operator/kube-prometheus#:~:text=x-,release%2D0.13,-%E2%9C%97)
```
(local-exec): + kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/release-0.11/manifests/setup/0servicemonitorCustomResourceDefinition.yaml
(local-exec): Unable to connect to the server: read tcp 192.168.29.234:52746->185.199.110.133:443: read: connection reset by peer
```