### PR TITLE
fix ipsec secret creation

### DIFF
--- a/scripts/provisioner.sh
+++ b/scripts/provisioner.sh
@@ -58,11 +58,12 @@ IPSEC_SECRET_NAME="cilium-ipsec-keys"
 if [[ "${IPSEC_KEY}" != "" ]];
 then
   IPSEC_ENABLED="true"
-  kubectl -n "${CILIUM_NAMESPACE}" create secret generic "${IPSEC_SECRET_NAME}" --from-literal=keys="${IPSEC_KEY}" --dry-run=client -o yaml | kubectl apply -f-
+  kubectl -n "${CILIUM_NAMESPACE}" create secret generic "${IPSEC_SECRET_NAME}" --from-literal=keys="3 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128" --dry-run=client -o yaml | kubectl apply -f-
 else
   IPSEC_ENABLED="false"
   kubectl -n "${CILIUM_NAMESPACE}" delete secret "${IPSEC_SECRET_NAME}" --ignore-not-found
 fi
+
 export IPSEC_ENABLED
 
 # Manually create the 'ServiceMonitor' CRD from 'kube-prometheus' so we can enable the creation of 'ServiceMonitor' resources in the Cilium Helm chart.


### PR DESCRIPTION
The current method of IPsec secret generation results in the following error in the Cilium agent container
`level=fatal msg="Error while creating daemon" error="unable to setup encryption: missing IPSec key or invalid format" subsys=daemon`

Changing the command, as per [this](https://docs.cilium.io/en/latest/security/network/encryption-ipsec/#generate-import-the-psk:~:text=be%20used.%20To-,generate%20the%20secret,-%2C%20you%20may%20use) doc.