### PR TITLE
Optionally wait for a full control-plane.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ No modules.
 | <a name="input_path_to_kubeconfig_file"></a> [path\_to\_kubeconfig\_file](#input\_path\_to\_kubeconfig\_file) | The path to the kubeconfig file to use. | `string` | n/a | yes |
 | <a name="input_post_cilium_install_script"></a> [post\_cilium\_install\_script](#input\_post\_cilium\_install\_script) | A script to be run right after installing Cilium. | `string` | `""` | no |
 | <a name="input_pre_cilium_install_script"></a> [pre\_cilium\_install\_script](#input\_pre\_cilium\_install\_script) | A script to be run right before installing Cilium. | `string` | `""` | no |
+| <a name="input_total_control_plane_nodes"></a> [total\_control\_plane\_nodes](#input\_total\_control\_plane\_nodes) | The number of control-plane nodes expected in the cluster. | `number` | `3` | no |
+| <a name="input_wait_for_total_control_plane_nodes"></a> [wait\_for\_total\_control\_plane\_nodes](#input\_wait\_for\_total\_control\_plane\_nodes) | Whether to wait for the expected number of control-plane nodes to be registered before applying any changes. | `bool` | `false` | no |
 
 ## Outputs
 

--- a/locals.tf
+++ b/locals.tf
@@ -13,21 +13,23 @@
 // limitations under the License.
 
 locals {
-  provisioner_environment = merge(var.extra_provisioner_environment_variables, local.provisioner_environment_variables)         // The full set of environment variables passed to the provisioning script.
-  provisioner_environment_variables = {                                                                                         // The set of environment variables set by this module on the provisioning script.
-    CILIUM_HELM_CHART                = var.cilium_helm_chart,                                                                   // The Cilium Helm chart to deploy.
-    CILIUM_HELM_EXTRA_ARGS           = var.cilium_helm_extra_args                                                               // Extra arguments to be passed to the 'helm upgrade --install' command that installs Cilium.
-    CILIUM_HELM_RELEASE_NAME         = var.cilium_helm_release_name,                                                            // The name to use for the Cilium Helm release.
-    CILIUM_HELM_VALUES_FILE          = var.cilium_helm_values_file_path,                                                        // The path to the Helm values file to use when installing Cilium.
-    CILIUM_HELM_VALUES_OVERRIDE_FILE = var.cilium_helm_values_override_file_path,                                               // The path to the Helm values override file to use when installing Cilium.
-    CILIUM_HELM_VERSION              = var.cilium_helm_version,                                                                 // The version of the Cilium Helm chart to deploy.
-    CILIUM_NAMESPACE                 = var.cilium_namespace,                                                                    // The namespace where to deploy Cilium.
-    DEPLOY_ETCD_CLUSTER              = var.deploy_etcd_cluster                                                                  // Whether to deploy an 'etcd' cluster suitable for usage as the Cilium key-value store.
-    INSTALL_KUBE_PROMETHEUS_CRDS     = true,                                                                                    // Whether to install (some of) the 'kube-prometheus' CRDs (such as 'ServiceMonitor').
-    IPSEC_KEY                        = var.ipsec_key,                                                                           // The IPsec key to be used for transparent encryption.
-    KUBECONFIG                       = var.path_to_kubeconfig_file                                                              // The path to the kubeconfig file that will be created and output.
-    PRE_CILIUM_INSTALL_SCRIPT        = var.pre_cilium_install_script != "" ? base64encode(var.pre_cilium_install_script) : ""   // The script to execute before installing Cilium.
-    POST_CILIUM_INSTALL_SCRIPT       = var.post_cilium_install_script != "" ? base64encode(var.post_cilium_install_script) : "" // The script to execute after installing Cilium.
+  provisioner_environment = merge(var.extra_provisioner_environment_variables, local.provisioner_environment_variables)           // The full set of environment variables passed to the provisioning script.
+  provisioner_environment_variables = {                                                                                           // The set of environment variables set by this module on the provisioning script.
+    CILIUM_HELM_CHART                  = var.cilium_helm_chart,                                                                   // The Cilium Helm chart to deploy.
+    CILIUM_HELM_EXTRA_ARGS             = var.cilium_helm_extra_args                                                               // Extra arguments to be passed to the 'helm upgrade --install' command that installs Cilium.
+    CILIUM_HELM_RELEASE_NAME           = var.cilium_helm_release_name,                                                            // The name to use for the Cilium Helm release.
+    CILIUM_HELM_VALUES_FILE            = var.cilium_helm_values_file_path,                                                        // The path to the Helm values file to use when installing Cilium.
+    CILIUM_HELM_VALUES_OVERRIDE_FILE   = var.cilium_helm_values_override_file_path,                                               // The path to the Helm values override file to use when installing Cilium.
+    CILIUM_HELM_VERSION                = var.cilium_helm_version,                                                                 // The version of the Cilium Helm chart to deploy.
+    CILIUM_NAMESPACE                   = var.cilium_namespace,                                                                    // The namespace where to deploy Cilium.
+    DEPLOY_ETCD_CLUSTER                = var.deploy_etcd_cluster                                                                  // Whether to deploy an 'etcd' cluster suitable for usage as the Cilium key-value store.
+    INSTALL_KUBE_PROMETHEUS_CRDS       = true,                                                                                    // Whether to install (some of) the 'kube-prometheus' CRDs (such as 'ServiceMonitor').
+    IPSEC_KEY                          = var.ipsec_key,                                                                           // The IPsec key to be used for transparent encryption.
+    KUBECONFIG                         = var.path_to_kubeconfig_file                                                              // The path to the kubeconfig file that will be created and output.
+    PRE_CILIUM_INSTALL_SCRIPT          = var.pre_cilium_install_script != "" ? base64encode(var.pre_cilium_install_script) : ""   // The script to execute before installing Cilium.
+    POST_CILIUM_INSTALL_SCRIPT         = var.post_cilium_install_script != "" ? base64encode(var.post_cilium_install_script) : "" // The script to execute after installing Cilium.
+    TOTAL_CONTROL_PLANE_NODES          = var.total_control_plane_nodes
+    WAIT_FOR_TOTAL_CONTROL_PLANE_NODES = var.wait_for_total_control_plane_nodes
   }
   provisioner_path = "${abspath(path.module)}/scripts/provisioner.sh"
 }

--- a/scripts/provisioner.sh
+++ b/scripts/provisioner.sh
@@ -49,6 +49,17 @@ done
 set -e
 sleep 10
 
+# If asked to, wait for the total number of control-plane nodes to be registered.
+set +e
+if [[ "${WAIT_FOR_TOTAL_CONTROL_PLANE_NODES}" == "true" ]];
+then
+  until [[ $(kubectl get node -l node-role.kubernetes.io/control-plane --no-headers | wc -l) == "${TOTAL_CONTROL_PLANE_NODES}" ]];
+  do
+    sleep 1
+  done
+fi
+set -e
+
 # Create the target namespace if it does not exist.
 kubectl create namespace "${CILIUM_NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
 

--- a/scripts/provisioner.sh
+++ b/scripts/provisioner.sh
@@ -47,7 +47,6 @@ do
   fi
 done
 set -e
-sleep 10
 
 # If asked to, wait for the total number of control-plane nodes to be registered.
 set +e

--- a/variables.tf
+++ b/variables.tf
@@ -85,3 +85,15 @@ variable "post_cilium_install_script" {
   description = "A script to be run right after installing Cilium."
   type        = string
 }
+
+variable "total_control_plane_nodes" {
+  default     = 3
+  description = "The number of control-plane nodes expected in the cluster."
+  type        = number
+}
+
+variable "wait_for_total_control_plane_nodes" {
+  default     = false
+  description = "Whether to wait for the expected number of control-plane nodes to be registered before applying any changes."
+  type        = bool
+}


### PR DESCRIPTION
This PR adds support for optionally waiting for a full control-plane. What a full control-plane means is defined by the value of the `total_control_plane_nodes` variable. To keep the default behaviour intact, `wait_for_total_control_plane_nodes` is `false` by default.

Also removing a call to `sleep` after testing for API server reachability that seems to me is not really necessary (but not super sure)? ( cc @PhilipSchmid on this one ).