### PR TITLE
Fixed total CP waiting loop condition

### DIFF
--- a/scripts/provisioner.sh
+++ b/scripts/provisioner.sh
@@ -53,7 +53,7 @@ set +e
 if [[ "${WAIT_FOR_TOTAL_CONTROL_PLANE_NODES}" == "true" ]];
 then
   WAIT_FOR_TOTAL_CONTROL_PLANE_NODES_ATTEMPT_NUM=1
-  until [[ $(kubectl get node -l "${CONTROL_PLANE_NODES_LABEL_SELECTOR}" --no-headers | wc -l) == "${TOTAL_CONTROL_PLANE_NODES}" ]];
+  until [[ $(kubectl get node -l "${CONTROL_PLANE_NODES_LABEL_SELECTOR}" --no-headers | wc -l | tr -d '[:space:]') == "${TOTAL_CONTROL_PLANE_NODES}" ]];
   do
     if [[ ${WAIT_FOR_TOTAL_CONTROL_PLANE_NODES_ATTEMPT_NUM} -gt 180 ]];
     then


### PR DESCRIPTION
Problem on macOS: There are white spaces in front of the `wc -l` output this leads to the situation that the condition is never true (`       3` != `3`).

```
│ + [[        3 == \3 ]]
│ + [[ 179 -gt 180 ]]
│ + WAIT_FOR_TOTAL_CONTROL_PLANE_NODES_ATTEMPT_NUM=180
│ + sleep 1
│ ++ kubectl get node -l node-role.kubernetes.io/control-plane --no-headers
│ ++ wc -l
│ + [[        3 == \3 ]]
│ + [[ 180 -gt 180 ]]
│ + WAIT_FOR_TOTAL_CONTROL_PLANE_NODES_ATTEMPT_NUM=181
│ + sleep 1
│ ++ kubectl get node -l node-role.kubernetes.io/control-plane --no-headers
│ ++ wc -l
│ + [[        3 == \3 ]]
│ + [[ 181 -gt 180 ]]
│ + echo 'Timed out while waiting for the total number of control-plane nodes.'
│ Timed out while waiting for the total number of control-plane nodes.
│ + exit 1
```

Reason: https://stackoverflow.com/a/30927885