### PR TITLE
add dependency trigger variable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -134,3 +134,9 @@ variable "cilium_wait_timer" {
   type        = number
   description = "Timer to wait for kubeconfig before completing the cilium install"
 }
+
+variable "dependency_trigger" {
+  description = "An arbitrary value that, when changed, can be used to trigger updates. Used here to enforce an implicit dependency on another module's resource."
+  type        = any
+  default     = null
+}


### PR DESCRIPTION
To enforce ordering between modules, especially in order to cater the logic introduced in https://github.com/isovalent/terraform-k8s-cilium-clustermesh/pull/19, where it is needed to add crds and issuer certsbefore cilium installation and certmanager to be installed post cilium installation.